### PR TITLE
fixing deprecation warnings for Elixir master

### DIFF
--- a/lib/ex_conf/utils.ex
+++ b/lib/ex_conf/utils.ex
@@ -2,7 +2,7 @@ defmodule ExConf.Utils do
 
   def capitalize(<<first, rest :: binary>>) do
     [first]
-    |> String.from_char_list!
+    |> String.from_char_data!
     |> String.upcase
     |> Kernel.<>(rest)
   end


### PR DESCRIPTION
Fixing warning when using Elixir 0.13.1-dev:

```
String.from_char_list!/1 is deprecated, please use String.from_char_data!/1 instead
```
