### PR TITLE
String.from_char_data! is no longer available, changing to use to_string

### DIFF
--- a/lib/ex_conf/utils.ex
+++ b/lib/ex_conf/utils.ex
@@ -2,7 +2,7 @@ defmodule ExConf.Utils do
 
   def capitalize(<<first, rest :: binary>>) do
     [first]
-    |> String.from_char_data!
+    |> to_string
     |> String.upcase
     |> Kernel.<>(rest)
   end


### PR DESCRIPTION
I'm running phoenix under v0.14.1-dev and when i run the unit tests i am receiving the following when it hits the ex_conf tests:

*\* (UndefinedFunctionError) undefined function: String.from_char_data!/1

Doing a little digging and it looks like the from_char_data/1 has be removed under v0.14.1-dev.  I changed it to use to_string and the unit tests are now passing.

After the change, i was able to generate new phoenix projects and then run tests in/on the project.

I did not up the version dependency in mix.exs.
